### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,14 +3,15 @@ Type: Package
 Title: Reproducible GSEA Benchmarking
 Version: 1.31.0
 Authors@R: c(
-    person("Ludwig", "Geistlinger",
-    email = "ludwig.geistlinger@gmail.com", role = c("aut", "cre")),
+    person("Ludwig", "Geistlinger", , "ludwig.geistlinger@gmail.com", role = c("aut", "cre")),
     person("Gergely", "Csaba", role = "aut"),
     person("Mara", "Santarelli", role = "ctb"),
     person("Lucas", "Schiffer", role = "ctb"),
     person("Marcel", "Ramos", role = "ctb"),
     person("Ralf", "Zimmer", role = "aut"),
-    person("Levi", "Waldron", role = "aut")
+    person("Levi", "Waldron", role = "aut"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "U24CA289073"))
   )
 Description:
     The GSEABenchmarkeR package implements an extendable framework for


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- U24CA289073

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616383375](https://github.com/waldronlab/repo-audits/actions/runs/23616383375)).